### PR TITLE
Remove the print of the path when reading a file

### DIFF
--- a/lib/Config/Parser/yaml.pm6
+++ b/lib/Config/Parser/yaml.pm6
@@ -9,7 +9,6 @@ class Config::Parser::yaml is Config::Parser
 {
     method read(Str $path --> Hash)
     {
-        say $path;
         load-yaml(slurp $path);
     }
 }


### PR DESCRIPTION
I think it's not necessary to print out the path of the file loaded. 

Regards.